### PR TITLE
URI of the investigation in the class group assignment is corrected

### DIFF
--- a/ClassgroupAssignments.owl
+++ b/ClassgroupAssignments.owl
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:vitro="http://vitro.mannlib.cornell.edu/ns/vitro/0.7#">
-  <rdf:Description rdf:about="http://w3id.org/rdfbones/extensions/FrNonMetricTraits#Investigation.FrNonMetricTraits">
+  <rdf:Description rdf:about="http://w3id.org/rdfbones/extensions/FrSexEst#Investigation.FrNonMetricTraits">
     <vitro:inClassGroup rdf:resource="http://vivoweb.org/ontology#vitroClassGroupInvestigations"/>
   </rdf:Description>
 </rdf:RDF>


### PR DESCRIPTION
With the correction, instances of the Investigation.FrNonMetricTraits can be added from the Site Admin page.